### PR TITLE
feat: load buildkit config from string instead of file

### DIFF
--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -95,7 +95,7 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "daemon.buildkit-config",
-			Usage:       "location of buildkit config file",
+			Usage:       "docker buildkit json config content",
 			EnvVars:     []string{"PLUGIN_BUILDKIT_CONFIG"},
 			Destination: &settings.Daemon.BuildkitConfig,
 		},

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,6 @@ github.com/drone-plugins/drone-plugin-lib v0.4.0/go.mod h1:EgqogX38GoJFtckeSQyhB
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -71,7 +70,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-honnef.co/go/tools v0.1.4 h1:SadWOkti5uVN1FAMgxn165+Mw00fuQKyk4Gyn/inxNQ=
-honnef.co/go/tools v0.1.4/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
 honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=

--- a/plugin/daemon.go
+++ b/plugin/daemon.go
@@ -1,13 +1,14 @@
 package plugin
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
 const dockerExe = "/usr/local/bin/docker"
 const dockerdExe = "/usr/local/bin/dockerd"
 const dockerHome = "/root/.docker/"
+const buildkitConfig = "/tmp/buildkit.json"
 
 func (p Plugin) startDaemon() {
 	cmd := commandDaemon(p.settings.Daemon)
@@ -15,8 +16,8 @@ func (p Plugin) startDaemon() {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	} else {
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
 	}
 	go func() {
 		trace(cmd)

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -54,13 +54,13 @@ func commandInfo() *exec.Cmd {
 
 func commandBuilder(daemon Daemon) *exec.Cmd {
 	args := []string{
-		"buildx", 
-		"create", 
+		"buildx",
+		"create",
 		"--use",
 	}
 
 	if daemon.BuildkitConfig != "" {
-		args = append(args, "--config", daemon.BuildkitConfig)
+		args = append(args, "--config", buildkitConfig)
 	}
 
 	return exec.Command(dockerExe, args...)
@@ -84,7 +84,7 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 	}
 
 	args = append(args, build.Context)
-	if ! dryrun {
+	if !dryrun {
 		args = append(args, "--push")
 	}
 	if build.Squash {
@@ -124,7 +124,7 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 
 	for _, arg := range build.Tags.Value() {
 		args = append(args, "-t", fmt.Sprintf("%s:%s", build.Repo, arg))
-	}	
+	}
 
 	return exec.Command(dockerExe, args...)
 }


### PR DESCRIPTION
BREAKING CHANGE: Loading the buildkit config from a file within your repository will not work anymore. You have to pass the buildkit config as a string instead. This way, you can add the config to a Drone secret as well to protect confidential values. Doing it this way will also align with the already implemented behavior for the docker login config.

Fixes: #36 