### PR TITLE
fix: fix auto_tag behavior to avoid unexpected publishing

### DIFF
--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -117,7 +117,6 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			Name:        "tags",
 			EnvVars:     []string{"PLUGIN_TAG", "PLUGIN_TAGS"},
 			Usage:       "sets repository tags to use for the image",
-			Value:       cli.NewStringSlice([]string{"latest"}...),
 			FilePath:    ".tags",
 			Destination: &settings.Build.Tags,
 		},

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -84,7 +84,7 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 	}
 
 	args = append(args, build.Context)
-	if !dryrun {
+	if !dryrun && len(build.Tags.Value()) > 0 {
 		args = append(args, "--push")
 	}
 	if build.Compress {

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -87,12 +87,12 @@ func (p *Plugin) Validate() error {
 				p.settings.Build.TagsSuffix,
 			)
 			if err != nil {
-				logrus.Printf("cannot build docker image for %s, invalid semantic version", p.settings.Build.Ref)
+				logrus.Printf("cannot generate tags from %s, invalid semantic version", p.settings.Build.Ref)
 				return err
 			}
 			p.settings.Build.Tags = *cli.NewStringSlice(tag...)
 		} else {
-			logrus.Printf("skipping automated docker build for %s", p.settings.Build.Ref)
+			logrus.Printf("skip auto-tagging for %s, not on default branch or tag", p.settings.Build.Ref)
 			return nil
 		}
 	}

--- a/plugin/tags_test.go
+++ b/plugin/tags_test.go
@@ -29,7 +29,7 @@ func TestDefaultTags(t *testing.T) {
 		After  []string
 	}{
 		{"", []string{"latest"}},
-		{"refs/heads/master", []string{"latest"}},
+		{"refs/heads/main", []string{"latest"}},
 		{"refs/tags/0.9.0", []string{"0.9", "0.9.0"}},
 		{"refs/tags/1.0.0", []string{"1", "1.0", "1.0.0"}},
 		{"refs/tags/v1.0.0", []string{"1", "1.0", "1.0.0"}},
@@ -142,9 +142,9 @@ func Test_stripHeadPrefix(t *testing.T) {
 	}{
 		{
 			args: args{
-				ref: "refs/heads/master",
+				ref: "refs/heads/main",
 			},
-			want: "master",
+			want: "main",
 		},
 	}
 	for _, tt := range tests {
@@ -167,8 +167,8 @@ func TestUseDefaultTag(t *testing.T) {
 		{
 			name: "latest tag for default branch",
 			args: args{
-				ref:           "refs/heads/master",
-				defaultBranch: "master",
+				ref:           "refs/heads/main",
+				defaultBranch: "main",
 			},
 			want: true,
 		},
@@ -176,7 +176,7 @@ func TestUseDefaultTag(t *testing.T) {
 			name: "build from tags",
 			args: args{
 				ref:           "refs/tags/v1.0.0",
-				defaultBranch: "master",
+				defaultBranch: "main",
 			},
 			want: true,
 		},
@@ -184,7 +184,7 @@ func TestUseDefaultTag(t *testing.T) {
 			name: "skip build for not default branch",
 			args: args{
 				ref:           "refs/heads/develop",
-				defaultBranch: "master",
+				defaultBranch: "main",
 			},
 			want: false,
 		},


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/drone-docker-buildx/issues/65
Supersedes: https://github.com/thegeeklab/drone-docker-buildx/pull/66

Fixed behavior:
- the plugin always builds the docker image if it is executed
- use auto_tag to tag `latest` on the configured default branch or `latest` + `semVer` tags on a matching tag
- use `tags` or a `.tags` file to specify the tags that should be used manually

BREAKING CHANGE: `latest` has been removed from the default `tags` list, which is now empty. You must specify `auto_tag` or `tags` option, otherwise the plugin will build but __never__ tag and push the image.