### PR TITLE
feat: add cache_to option and remove manual image pull for cache_from images

### DIFF
--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -143,6 +143,11 @@ properties:
     type: list
     required: false
 
+  cache_to:
+    description: [Cache destination](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to) for the build cache.
+    type: string
+    required: false
+
   pull_image:
     description: Enforce to pull the base image at build time.
     defaultValue: true

--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -201,6 +201,13 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Destination: &settings.Build.CacheFrom,
 			Category:    category,
 		},
+		&cli.StringFlag{
+			Name:        "cache-to",
+			EnvVars:     []string{"PLUGIN_CACHE_TO"},
+			Usage:       "cache destination for the build cache",
+			Destination: &settings.Build.CacheTo,
+			Category:    category,
+		},
 		&cli.BoolFlag{
 			Name:        "pull-image",
 			EnvVars:     []string{"PLUGIN_PULL_IMAGE"},

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -23,15 +23,6 @@ func commandLogin(login Login) *exec.Cmd {
 	)
 }
 
-// helper to check if args match "docker pull <image>"
-func isCommandPull(args []string) bool {
-	return len(args) > 2 && args[1] == "pull"
-}
-
-func commandPull(repo string) *exec.Cmd {
-	return exec.Command(dockerExe, "pull", repo)
-}
-
 func commandLoginEmail(login Login) *exec.Cmd {
 	return exec.Command(
 		dockerExe, "login",
@@ -98,6 +89,9 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 	}
 	for _, arg := range build.CacheFrom.Value() {
 		args = append(args, "--cache-from", arg)
+	}
+	if build.CacheTo != "" {
+		args = append(args, "--cache-to", build.CacheTo)
 	}
 	for _, arg := range build.ArgsEnv.Value() {
 		addProxyValue(&build, arg)

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -53,6 +53,7 @@ type Build struct {
 	Target       string          // Docker build target
 	Pull         bool            // Docker build pull
 	CacheFrom    cli.StringSlice // Docker build cache-from
+	CacheTo      string          // Docker build cache-to
 	Compress     bool            // Docker build compress
 	Repo         string          // Docker build repository
 	NoCache      bool            // Docker build no-cache
@@ -166,11 +167,6 @@ func (p *Plugin) Execute() error {
 	cmds = append(cmds, commandBuilder(p.settings.Daemon))
 	cmds = append(cmds, commandBuildx())
 
-	// pre-pull cache images
-	for _, img := range p.settings.Build.CacheFrom.Value() {
-		cmds = append(cmds, commandPull(img))
-	}
-
 	cmds = append(cmds, commandBuild(p.settings.Build, p.settings.Dryrun)) // docker build
 
 	// execute all commands in batch mode.
@@ -180,9 +176,7 @@ func (p *Plugin) Execute() error {
 		trace(cmd)
 
 		err := cmd.Run()
-		if err != nil && isCommandPull(cmd.Args) {
-			fmt.Printf("Could not pull cache-from image %s. Ignoring...\n", cmd.Args[2])
-		} else if err != nil {
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The way of using `cache_from` as described in #47 does not work for me. If I use an image in `cache_from` which was built via a normal docker build step, the build does not use any cached layers. Instead, everything is pulled and run again.

Reading the documentation, it seems when using `cache_to`, buildkit writes a different kind of manifest (the "cache manifest"). (See [here](https://github.com/moby/buildkit/issues/2251) for some context.) So in order to make caching work, we need to add this option.

With this PR, we can now use it like this:

```yaml
steps:
  - name: build image
    image: thegeeklab/drone-docker-buildx
    settings:
      repo: my/image
      cache_from: my/image:cache
      cache_to: my/image:cache
```

With this change, I was able to re-run a build which initially took 1,5 hours in 26 seconds. 

Also, buildkit seems to automatically pull all the images specified in the `cache_from` option. Thus the manual pre-pull of those images is not necessary. So I removed it.