### PR TITLE
feat: add `extra_tags` option to set tags including additional registries

### DIFF
--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -118,7 +118,10 @@ properties:
     required: false
 
   extra_tags:
-    description: Set additional tags which include the resgitry.
+    description: |
+      Set additional tags to be used for the image. Additional tags can also be loaded from an `.extratags` file. This function can be used
+      to push images to multiple registries at once. Therefore, it is necessary to use the `config` flag to provide a configuration file
+      that contains the authentication information for all used registries.
     type: list
     required: false
 

--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -117,6 +117,11 @@ properties:
     type: string
     required: false
 
+  extra_tags:
+    description: Set additional tags which include the resgitry.
+    type: list
+    required: false
+
   build_args:
     description: Ccustom build arguments to pass to the build.
     type: list

--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -159,6 +159,13 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Category:    category,
 		},
 		&cli.StringSliceFlag{
+			Name:        "extra.tags",
+			EnvVars:     []string{"PLUGIN_EXTRA_TAGS"},
+			Usage:       "extra tags to use for the image including registry",
+			Destination: &settings.Build.ExtraTags,
+			Category:    category,
+		},
+		&cli.StringSliceFlag{
 			Name:        "args",
 			EnvVars:     []string{"PLUGIN_BUILD_ARGS"},
 			Usage:       "custom build arguments for the build",

--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -161,7 +161,8 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:        "extra.tags",
 			EnvVars:     []string{"PLUGIN_EXTRA_TAGS"},
-			Usage:       "extra tags to use for the image including registry",
+			Usage:       "additional tags to use for the image including registry",
+			FilePath:    ".extratags",
 			Destination: &settings.Build.ExtraTags,
 			Category:    category,
 		},

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -123,6 +123,10 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 		args = append(args, "-t", fmt.Sprintf("%s:%s", build.Repo, arg))
 	}
 
+	for _, arg := range build.ExtraTags.Value() {
+		args = append(args, "-t", arg)
+	}
+
 	for _, arg := range build.Labels.Value() {
 		args = append(args, "--label", arg)
 	}

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -47,6 +47,7 @@ type Build struct {
 	TagsAuto     bool            // Docker build auto tag
 	TagsSuffix   string          // Docker build tags with suffix
 	Tags         cli.StringSlice // Docker build tags
+	ExtraTags    cli.StringSlice // Docker build tags including registry
 	Platforms    cli.StringSlice // Docker build target platforms
 	Args         cli.StringSlice // Docker build args
 	ArgsEnv      cli.StringSlice // Docker build args from env


### PR DESCRIPTION
The tags setting adds a registry automatically. Buildx supports pushing to multiple registries specified as tags.

This PR adds an extra_tags setting which allows for the specification of additional tags which include the registry.

https://github.com/moby/buildkit#imageregistry