### PR TITLE
fix: allow escaping of commas in plugin list options

### DIFF
--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/thegeeklab/drone-docker-buildx/plugin"
+	"github.com/thegeeklab/drone-plugin-lib/v2/drone"
 	"github.com/urfave/cli/v2"
 )
 
@@ -202,12 +203,12 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Destination: &settings.Build.Target,
 			Category:    category,
 		},
-		&cli.StringSliceFlag{
-			Name:        "cache-from",
-			EnvVars:     []string{"PLUGIN_CACHE_FROM"},
-			Usage:       "images to consider as cache sources",
-			Destination: &settings.Build.CacheFrom,
-			Category:    category,
+		&cli.GenericFlag{
+			Name:     "cache-from",
+			EnvVars:  []string{"PLUGIN_CACHE_FROM"},
+			Usage:    "images to consider as cache sources",
+			Value:    &drone.StringSliceFlag{},
+			Category: category,
 		},
 		&cli.StringFlag{
 			Name:        "cache-to",

--- a/cmd/drone-docker-buildx/main.go
+++ b/cmd/drone-docker-buildx/main.go
@@ -29,11 +29,12 @@ func main() {
 	}
 
 	app := &cli.App{
-		Name:    "drone-docker-buildx",
-		Usage:   "build docker container with DinD and buildx",
-		Version: BuildVersion,
-		Flags:   append(settingsFlags(settings, urfave.FlagsPluginCategory), urfave.Flags()...),
-		Action:  run(settings),
+		Name:               "drone-docker-buildx",
+		Usage:              "build docker container with DinD and buildx",
+		Version:            BuildVersion,
+		Flags:              append(settingsFlags(settings, urfave.FlagsPluginCategory), urfave.Flags()...),
+		SliceFlagSeparator: ";",
+		Action:             run(settings),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/drone-docker-buildx/main.go
+++ b/cmd/drone-docker-buildx/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thegeeklab/drone-docker-buildx/plugin"
 	"github.com/urfave/cli/v2"
 
+	"github.com/thegeeklab/drone-plugin-lib/v2/drone"
 	"github.com/thegeeklab/drone-plugin-lib/v2/urfave"
 )
 
@@ -29,12 +30,11 @@ func main() {
 	}
 
 	app := &cli.App{
-		Name:               "drone-docker-buildx",
-		Usage:              "build docker container with DinD and buildx",
-		Version:            BuildVersion,
-		Flags:              append(settingsFlags(settings, urfave.FlagsPluginCategory), urfave.Flags()...),
-		SliceFlagSeparator: ";",
-		Action:             run(settings),
+		Name:    "drone-docker-buildx",
+		Usage:   "build docker container with DinD and buildx",
+		Version: BuildVersion,
+		Flags:   append(settingsFlags(settings, urfave.FlagsPluginCategory), urfave.Flags()...),
+		Action:  run(settings),
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -45,6 +45,8 @@ func main() {
 func run(settings *plugin.Settings) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		urfave.LoggingFromContext(ctx)
+
+		settings.Build.CacheFrom = ctx.Generic("cache-from").(*drone.StringSliceFlag).Get()
 
 		plugin := plugin.New(
 			*settings,

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -87,7 +87,7 @@ func commandBuild(build Build, dryrun bool) *exec.Cmd {
 	if build.NoCache {
 		args = append(args, "--no-cache")
 	}
-	for _, arg := range build.CacheFrom.Value() {
+	for _, arg := range build.CacheFrom {
 		args = append(args, "--cache-from", arg)
 	}
 	if build.CacheTo != "" {

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -53,7 +53,7 @@ type Build struct {
 	ArgsEnv      cli.StringSlice // Docker build args from env
 	Target       string          // Docker build target
 	Pull         bool            // Docker build pull
-	CacheFrom    cli.StringSlice // Docker build cache-from
+	CacheFrom    []string        // Docker build cache-from
 	CacheTo      string          // Docker build cache-to
 	Compress     bool            // Docker build compress
 	Repo         string          // Docker build repository


### PR DESCRIPTION
Plugin **list** options that are using `commans` in its items need to be escaped. Example:

```
settings:
      daemon_off: true
      cache_from: 
       - "type=registry\\,ref=example"
       - "type=foo\\,ref=bar"
```

Fixes: https://github.com/thegeeklab/drone-docker-buildx/issues/141