### PR TITLE
chore: remove unused purge parameter

### DIFF
--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -208,12 +208,6 @@ properties:
     type: string
     required: false
 
-  purge:
-    description: Enable cleanup of the docker environment at the end of a build.
-    defaultValue: true
-    type: bool
-    required: false
-
   no_cache:
     description: Disable the usage of cached intermediate containers.
     defaultValue: false

--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -277,14 +277,6 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Category:    category,
 		},
 		&cli.BoolFlag{
-			Name:        "docker.purge",
-			EnvVars:     []string{"PLUGIN_PURGE"},
-			Usage:       "enable cleanup of the docker environment at the end of a build",
-			Value:       true,
-			Destination: &settings.Cleanup,
-			Category:    category,
-		},
-		&cli.BoolFlag{
 			Name:        "no-cache",
 			EnvVars:     []string{"PLUGIN_NO_CACHE"},
 			Usage:       "disable the usage of cached intermediate containers",

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -67,11 +67,10 @@ type Build struct {
 
 // Settings for the Plugin.
 type Settings struct {
-	Daemon  Daemon
-	Login   Login
-	Build   Build
-	Dryrun  bool
-	Cleanup bool
+	Daemon Daemon
+	Login  Login
+	Build  Build
+	Dryrun bool
 }
 
 // Validate handles the settings validation of the plugin.


### PR DESCRIPTION
The `purge` parameter wasn't fully implemented. By default, build artifacts are only stored in the build cache if no `output` is specified and nothing need to be cleanup up.