### PR TITLE
expose driver config

### DIFF
--- a/cmd/drone-docker-buildx/config.go
+++ b/cmd/drone-docker-buildx/config.go
@@ -114,6 +114,20 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Category:    category,
 		},
 		&cli.StringFlag{
+			Name:        "daemon.buildkit-driver",
+			EnvVars:     []string{"PLUGIN_BUILDKIT_DRIVER"},
+			Usage:       "set the builder driver to use",
+			Destination: &settings.Daemon.Driver,
+			Category:    category,
+		},
+		&cli.StringFlag{
+			Name:        "daemon.buildkit-driver-opt",
+			EnvVars:     []string{"PLUGIN_BUILDKIT_DRIVER_OPT"},
+			Usage:       "set additional driver-specific options",
+			Destination: &settings.Daemon.DriverOpt,
+			Category:    category,
+		},
+		&cli.StringFlag{
 			Name:        "dockerfile",
 			EnvVars:     []string{"PLUGIN_DOCKERFILE"},
 			Usage:       "dockerfile to use for the image build",

--- a/plugin/docker.go
+++ b/plugin/docker.go
@@ -54,6 +54,14 @@ func commandBuilder(daemon Daemon) *exec.Cmd {
 		args = append(args, "--config", buildkitConfig)
 	}
 
+	if daemon.Driver != "" {
+		args = append(args, "--driver", daemon.Driver)
+	}
+
+	if daemon.DriverOpt != "" {
+		args = append(args, "--driver-opt", daemon.DriverOpt)
+	}
+
 	return exec.Command(dockerExe, args...)
 }
 

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -27,6 +27,8 @@ type Daemon struct {
 	IPv6           bool            // Docker daemon IPv6 networking
 	Experimental   bool            // Docker daemon enable experimental mode
 	BuildkitConfig string          // Docker buildkit config
+	Driver         string          // Docker buildkit driver
+	DriverOpt      string          // Docker buildkit driver-opt
 }
 
 // Login defines Docker login parameters.


### PR DESCRIPTION
It allows to use custom driver config. It can be used to install private CA inside buildx. That way insecure access is not required.
```
buildkit_driver: docker-container
buildkit_driver_opt: image=private_registry/buildx_with_ca:latest
```