### PR TITLE
Fix documentation about "Multiple registries"

### DIFF
--- a/_docs/content/_index.md
+++ b/_docs/content/_index.md
@@ -104,6 +104,18 @@ name: default
 steps:
   - name: docker
     image: thegeeklab/drone-docker-buildx:23
+    commands:
+      - |
+        export PLUGIN_REGISTRIES=$(cat <<EOF
+        registries:
+          - username: "octocat"
+            password: "$${DOCKER_REGISTRY_PASSWORD}"
+          - registry: "ghcr.io"
+            username: "octocat"
+            password: "$${GITHUB_REGISTRY_PASSWORD}"
+        EOF
+        )        
+      - drone-docker-buildx
     privileged: true
     environment:
       DOCKER_REGISTRY_PASSWORD:
@@ -115,15 +127,26 @@ steps:
         - octocat/example
         - ghcr.io/octocat/example
       tags: latest
-      registries: |
-      registries:                                                                                                                                              
-        - username: "octocat"
-          password: "$DOCKER_REGISTRY_PASSWORD"
-        - registry: "ghcr.io"
-          username: "octocat"
-          password: "$GITHUB_REGISTRY_PASSWORD"
 ```
 
+OR
+
+```yaml
+kind: pipeline
+name: default
+
+steps:
+  - name: docker
+    image: thegeeklab/drone-docker-buildx:23
+    privileged: true
+    settings:
+      repo: 
+        - octocat/example
+        - ghcr.io/octocat/example
+      tags: latest
+      registries:
+        from_secret: registries_data
+```
 
 ## Build
 


### PR DESCRIPTION
I added the ability to publish to multiple registries (#303), but unfortunately I made a mistake in the documentation :confused:.

I tested pipeline with an image `thegeeklab/drone-docker-buildx@sha256:4ae2aa1ebd0150e6c32533238c304221ca0dcc2c02710b12f9facd565d439364` and released that the settings section as a environment section ["cannot expand environment variables or evaluate shell expressions"](https://docs.drone.io/pipeline/environment/syntax/#common-problems).

So I propose two ways to use the "registries" option with secrets:

1. using "export PLUGIN_REGISTRIES..." in the commands section with the option to separate the credentials in different secrets (now i use like this);
2. storing all data in one secret in the required format;

I have described examples of configurations, but perhaps more text description is required.